### PR TITLE
Stage 0 setup scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ These instructions apply to the entire repository. Update this file if new subdi
 ## Workflow Requirements
 
 - **Dependencies:** Before pushing significant Lean changes, verify that the dependency configuration in `lakefile.lean` imports `mathlib` and run `lake update` if new packages are added.
+  - The container bootstrap already runs `lake update`, `lake exe cache get`, and `lake build`, so cached dependencies should be ready unless you introduce new requirements.
 - **Build checks:** Run `lake build` after modifying Lean files. Record the command in the PR/testing notes.
 - **Linting:** Execute `#lint` (or `lake exe lint` when available) before each commit to confirm that the intermediate results are fully verified and there are no unintentional omissions.
 - **File organization:**

--- a/Formalization/Basic.lean
+++ b/Formalization/Basic.lean
@@ -1,1 +1,20 @@
-def hello := "world"
+import Mathlib
+
+/-!
+### Stage 0 — Project setup
+
+This module records the initial project namespace and a minimal sanity check
+that Lean can see the `SimpleGraph` API from `mathlib`.  The actual
+formalization will live in later modules following the staged plan from the
+`README`.
+-/
+
+namespace Codex
+
+/-- Stage 0 sanity check: the empty simple graph on one vertex. -/
+def stage0EmptyGraph : SimpleGraph (Fin 1) := ⊥
+
+example : ¬ stage0EmptyGraph.Adj (0 : Fin 1) (0 : Fin 1) := by
+  simp [stage0EmptyGraph]
+
+end Codex

--- a/Formalization/Scratch.lean
+++ b/Formalization/Scratch.lean
@@ -1,0 +1,17 @@
+import Mathlib
+
+/-!
+### Stage 0 — Scratchpad
+
+This file is not imported by the main library.  It exists as a sandbox for
+experiments while formalizing the paper.  Temporary definitions and `#eval`
+statements should live here before being promoted to the structured
+`Formalization/` hierarchy.
+-/
+
+namespace Codex
+
+-- TODO(Stage 1): move exploratory graph lemmas here before integrating them
+-- into the main development.
+
+end Codex

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ that guarantee the mechanized statements coincide with those of the paper.
 - Create a scratch file (e.g., `Formalization/Scratch.lean`) for experiments before incorporating statements into the main hierarchy.
 - **Verification approach.** Maintain a `#check`/`#eval` scratchpad for each new definition before moving it into the hierarchy. Run `#lint` after every stage to confirm there are no unused definitions or missing proofs.
 
+*Status (Stage 0):* The namespace `Codex` now lives in `Formalization/Basic.lean`, accompanied by a trivial `SimpleGraph` sanity check so future imports confirm access to `mathlib`.  A dedicated scratchpad (`Formalization/Scratch.lean`) is available for experiments.  Fetching external dependencies still requires a successful `lake update`; the current execution environment returned a transient network error, so the command should be retried during the next working session.
+
 ### Stage 1 — Graph-Theoretic Foundations
 
 Goal: formalize the deterministic combinatorial ingredients used across the paper.

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,15 @@
+# Project metadata for linting support.
+# The packages listed here are required to build and run `lake exe lint`
+# as provided by mathlib.
+[lint]
+packages = [
+  "leanprover-community/mathlib",
+  "leanprover-community/proofwidgets",
+  "leanprover-community/aesop",
+  "leanprover-community/Qq",
+  "leanprover-community/import-graph",
+  "leanprover-community/LeanSearchClient",
+  "leanprover-community/plausible",
+  "leanprover-community/batteries",
+  "leanprover/lean4-cli"
+]


### PR DESCRIPTION
## Summary
- replace the placeholder module with a `Codex` namespace and a trivial `SimpleGraph` sanity check to confirm Stage 0 visibility of mathlib.
- add a Stage 0 status note to the roadmap and introduce a dedicated scratchpad file for exploratory work.
- document the packages required for `lake exe lint` in `project.toml` and note in `AGENTS.md` that the container bootstrap already runs `lake update`, `lake exe cache get`, and `lake build`.

## Testing
- `lake build` *(fails: external command `git` exited with code 128 in the offline container while trying to contact remotes)*
- `lake env lean Lint.lean`

------
https://chatgpt.com/codex/tasks/task_e_68cc150f89b08323ac4968751389086c