### PR TITLE
Add copy counting lemmas for Stage 1 complete graphs

### DIFF
--- a/Formalization/Stage1/FiniteSimpleGraphs.lean
+++ b/Formalization/Stage1/FiniteSimpleGraphs.lean
@@ -64,4 +64,67 @@ example : edgeCount (SimpleGraph.completeGraph (Fin 3)) = 3 := by
   have : Nat.choose 3 2 = 3 := by decide
   simpa [this] using h
 
+/-- Stage 1 definition: the number of labelled copies of `H` inside `G` is the
+`Fintype` cardinality of graph embeddings from `H` to `G`. -/
+noncomputable def countCopies {α β : Type*} [Fintype α] [Fintype β]
+    (H : SimpleGraph α) (G : SimpleGraph β) : ℕ :=
+  Fintype.card (H ↪g G)
+
+section CopyCounting
+
+variable {α β : Type*} [Fintype α] [Fintype β]
+
+open Function
+
+/-- Stage 1 lemma: embeddings between complete graphs correspond exactly to
+type embeddings, so the copy count reduces to `Function.Embedding`. -/
+lemma countCopies_completeGraph_eq_card :
+    countCopies (SimpleGraph.completeGraph α) (SimpleGraph.completeGraph β)
+      = Fintype.card (α ↪ β) := by
+  classical
+  refine Fintype.card_congr ?_
+  refine
+    { toFun := fun f => f.toEmbedding
+      invFun := fun f => SimpleGraph.Embedding.completeGraph f
+      left_inv := ?_
+      right_inv := ?_ }
+  · intro f; ext v; rfl
+  · intro f; ext v; rfl
+
+/-- Stage 1 lemma: the number of labelled embeddings from a complete graph on
+`α` to one on `β` is the descending factorial counting injections between the
+vertex sets. -/
+lemma countCopies_completeGraph_eq_descFactorial :
+    countCopies (SimpleGraph.completeGraph α) (SimpleGraph.completeGraph β)
+      = (Fintype.card β).descFactorial (Fintype.card α) := by
+  classical
+  calc
+    countCopies (SimpleGraph.completeGraph α) (SimpleGraph.completeGraph β)
+        = Fintype.card (α ↪ β) :=
+      countCopies_completeGraph_eq_card (α := α) (β := β)
+    _ = (Fintype.card β).descFactorial (Fintype.card α) :=
+      (Fintype.card_embedding_eq (α := α) (β := β))
+
+/-- Stage 1 lemma specialized to labelled graphs on `Fin`. -/
+lemma countCopies_completeGraph_fin (k n : ℕ) :
+    countCopies (SimpleGraph.completeGraph (Fin k))
+        (SimpleGraph.completeGraph (Fin n)) = Nat.descFactorial n k := by
+  classical
+  calc
+    countCopies (SimpleGraph.completeGraph (Fin k))
+        (SimpleGraph.completeGraph (Fin n))
+        = (Fintype.card (Fin n)).descFactorial (Fintype.card (Fin k)) :=
+      countCopies_completeGraph_eq_descFactorial (α := Fin k) (β := Fin n)
+    _ = Nat.descFactorial n k := by simp [Fintype.card_fin]
+
+/-- Sanity check: there are six labelled embeddings of the complete graph on
+two vertices into the complete graph on three vertices. -/
+example :
+    countCopies (SimpleGraph.completeGraph (Fin 2))
+        (SimpleGraph.completeGraph (Fin 3)) = 6 := by
+  classical
+  simp [countCopies_completeGraph_fin]
+
+end CopyCounting
+
 end Codex


### PR DESCRIPTION
## Summary
- define `countCopies` as the cardinality of graph embeddings between finite simple graphs
- prove explicit formulas for embeddings between complete graphs, including the descending factorial specialization on `Fin`
- add a small sanity-check example for the `Fin 2` into `Fin 3` case to validate the normalization

## Testing
- lake build
- lake env lean Lint.lean

------
https://chatgpt.com/codex/tasks/task_e_68cc284b0384832382bb3c060ca903fa