### PR TITLE
feat(stage1): add count copy invariance under graph isomorphisms

### DIFF
--- a/Formalization/Stage1/FiniteSimpleGraphs.lean
+++ b/Formalization/Stage1/FiniteSimpleGraphs.lean
@@ -248,6 +248,47 @@ example :
   classical
   simp [countCopies_completeGraph_fin]
 
+/-- Stage 1 lemma: isomorphic host graphs admit equally many labelled copies. -/
+lemma countCopies_congr_right {H : SimpleGraph α}
+    {G G' : SimpleGraph β} (e : G ≃g G') :
+    countCopies H G = countCopies H G' := by
+  classical
+  refine Fintype.card_congr ?_
+  refine
+    { toFun := fun f => e.toEmbedding.comp f
+      invFun := fun f => e.symm.toEmbedding.comp f
+      left_inv := ?_
+      right_inv := ?_ }
+  · intro f; ext v; simp
+  · intro f; ext v; simp
+
+/-- Stage 1 lemma: isomorphic pattern graphs yield the same copy count in any
+ambient host. -/
+lemma countCopies_congr_left {H H' : SimpleGraph α}
+    {G : SimpleGraph β} (e : H ≃g H') :
+    countCopies H G = countCopies H' G := by
+  classical
+  refine Fintype.card_congr ?_
+  refine
+    { toFun := fun f => f.comp e.symm.toEmbedding
+      invFun := fun f => f.comp e.toEmbedding
+      left_inv := ?_
+      right_inv := ?_ }
+  · intro f; ext v; simp
+  · intro f; ext v; simp
+
+/-- Sanity check: permuting the vertices of `K₂` does not affect copy counts. -/
+example :
+    countCopies (SimpleGraph.completeGraph (Fin 2))
+        (SimpleGraph.completeGraph (Fin 3))
+      = countCopies (SimpleGraph.completeGraph (Fin 2))
+        (SimpleGraph.completeGraph (Fin 3)) := by
+  classical
+  simpa using
+    countCopies_congr_left
+      (G := SimpleGraph.completeGraph (Fin 3))
+      (e := SimpleGraph.Iso.completeGraph (Equiv.swap (0 : Fin 2) 1))
+
 end CopyCounting
 
 section EdgeInduced

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Key tasks and Lean checks:
    - Provide automation lemmas showing the closure of subgraphs under intersection/union when needed for counting arguments.
    - Use Lean's rewriting tools (`by_cases`, `simp`, `finset.induction`) to verify every structural property, recording each as a lemma reusable in later stages.
 
-*Status (Stage 1):* We now have Stage 1 utilities in `Formalization/Stage1/FiniteSimpleGraphs.lean` that build graphs from explicit edge sets and prove basic edge-count lemmas (including the monotonicity of `edgeCount` and the `n.choose 2` edge count for complete graphs).  Edge-induced subgraphs, along with union/intersection closure lemmas and finite edge-count computations, are available to support the upcoming copy-counting and subgraph arguments.
+*Status (Stage 1):* We now have Stage 1 utilities in `Formalization/Stage1/FiniteSimpleGraphs.lean` that build graphs from explicit edge sets and prove basic edge-count lemmas (including the monotonicity of `edgeCount` and the `n.choose 2` edge count for complete graphs).  Edge-induced subgraphs, along with union/intersection closure lemmas and finite edge-count computations, are available to support the upcoming copy-counting and subgraph arguments.  Additionally, the new copy-counting lemmas confirm that isomorphic pattern or host graphs yield identical enumerations of labelled embeddings.
 
 ### Stage 2 — Random Graph Model and Expectations
 


### PR DESCRIPTION
## Summary
- add lemmas showing `countCopies` is preserved under graph isomorphisms on either the host or pattern graph
- include a sanity check example using a transposition of `Fin 2`
- document the new Stage 1 progress in the README

## Testing
- `lake build`
- `lake env lean --stdin <<'LEAN'
import Formalization
#lint
LEAN`


------
https://chatgpt.com/codex/tasks/task_e_68cc6d2a0a90832399459b7a23a70ea4