### PR TITLE
stage1: roll back broken double-counting extension

### DIFF
--- a/Formalization/Stage1/DebugNotes.md
+++ b/Formalization/Stage1/DebugNotes.md
@@ -1,0 +1,12 @@
+# Stage 1 debugging notes (2024-)
+
+* The attempt to extend embeddings `J ↪g K_n` to permutations of `Fin n` relied on
+  `Function.Embedding.comp`/`equivRange` and `Equiv.toPerm`.  Mathlib only exposes
+  these constructions for `Embedding`, so the earlier code failed to compile.  We
+  removed the broken lemmas and will rebuild the argument directly with
+  `Embedding` utilities or a group-action approach.
+* The combinatorial probability lemma
+  `uniformProbability_contains_fixed` was rolled back until the permutation
+  extension is reconstructed.  The foundational bijection
+  `embeddingsIntoRangeEquiv` and its ratio corollary remain available for the
+  double-counting argument.

--- a/Formalization/Stage1/FiniteSimpleGraphs.lean
+++ b/Formalization/Stage1/FiniteSimpleGraphs.lean
@@ -296,6 +296,8 @@ section DoubleCounting
 variable {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
 
 open Classical
+open scoped BigOperators
+open Equiv
 
 /--
 Stage 1 bijection: embeddings of `J` into `H` correspond exactly to the
@@ -466,6 +468,14 @@ example :
       (H := SimpleGraph.completeGraph (Fin 3))
       (n := 4) f
   simpa [f] using hf
+
+
+-- TODO (Stage 1): Revisit the constant-fibre argument for embeddings into a fixed
+-- copy of `J` inside `K_n`.  The previous attempt relied on extending embeddings
+-- to permutations of `Fin n`, but the construction used non-existent
+-- `Function.Embedding` helpers.  Once the permutation extension is rebuilt,
+-- restore the lemma computing the probability that a random labelled copy of `H`
+-- contains a fixed copy of `J`.
 
 end DoubleCounting
 


### PR DESCRIPTION
## Summary
- drop the non-compiling permutation-extension lemmas from the Stage 1 double-counting file and replace them with a TODO marker
- retain the working range-containment bijection while documenting the missing probability lemma in a Stage 1 debug note
- record the debugging takeaways in `Formalization/Stage1/DebugNotes.md`

## Testing
- `lake build`
- `printf 'import Formalization.Stage1.FiniteSimpleGraphs\n#lint\n' | lake env lean --stdin`


------
https://chatgpt.com/codex/tasks/task_e_68cebd4b11e08323a20961b8fb6c86ad