### PR TITLE
docs: stress manifest lockfile policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ These instructions apply to the entire repository. Update this file if new subdi
 ## Workflow Requirements
 
 - **Environment limitations:** After the container launches there is no internet access. Commands such as `lake update` and `lake exe cache get` will fail; do not attempt them inside the session. Record dependency changes in `lakefile.lean` and escalate the request to the maintainer so they can refresh caches externally.
-- **Dependency lockfiles:** Never revert `lake-manifest.json`. The manifest was produced by a known-good `lake update`, and without network access the cached packages must stay in sync with that exact revision for `lake build` to succeed.
+- **Dependency lockfiles:** `lake-manifest.json` is a pinned artifact from a maintainer-run `lake update`. Treat it as read-only: never roll it back to an earlier commit or swap in a different revision unless the maintainer supplies a replacement manifest. When the repository history introduces an updated manifest, keep that change intact rather than undoing it, because the cached dependencies inside the container are only compatible with the committed file.
 - **Dependencies:** Before pushing significant Lean changes, verify that the dependency configuration in `lakefile.lean` imports `mathlib` and accurately lists any new packages you require.
   - Because network-dependent commands cannot be executed inside the container, treat `lakefile.lean` as the source of truth for dependencies, document the needed updates in your notes, and ask the maintainer to run the necessary cache refreshes outside the environment.
 - **Build checks:** Run `lake build` after modifying Lean files. Record the command in the PR/testing notes.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The project uses Lean `v4.24.0-rc1` (see `lean-toolchain`). The plan below recor
 ## Development Environment Constraints
 
 - After the container launches there is no internet access. Commands such as `lake update` and `lake exe cache get` will fail inside the session. Record any dependency changes directly in `lakefile.lean` and notify the maintainer so they can refresh caches outside the container.
+- Treat `lake-manifest.json` as an immutable lockfile. **Never revert or "clean up" this file**, even if it appears modified—leave the tracked version untouched unless a maintainer explicitly supplies a replacement manifest produced outside the container.
 
 ## Formalization Plan
 


### PR DESCRIPTION
## Summary
- spell out in README.md that lake-manifest.json must never be reverted or "tidied" without maintainer approval
- expand the repo-wide AGENTS.md guidance so contributors keep maintainer-provided manifest updates and avoid rolling the lockfile back

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d278a22e488323b26987dd210fc01e