### PR TITLE
Stage2: add random graph measure and measurability

### DIFF
--- a/Formalization.lean
+++ b/Formalization.lean
@@ -2,3 +2,4 @@
 -- Import modules here that should be built as part of the library.
 import Formalization.Basic
 import Formalization.Stage1.FiniteSimpleGraphs
+import Formalization.Stage2.RandomGraph

--- a/Formalization/Stage2/RandomGraph.lean
+++ b/Formalization/Stage2/RandomGraph.lean
@@ -1,0 +1,144 @@
+import Mathlib
+import Formalization.Stage1.FiniteSimpleGraphs
+
+/-!
+### Stage 2 — Random graph model
+
+This module begins Stage 2 of the formalization plan by modelling the
+binomial random graph `G(n, p)` as a product probability measure on the
+indicator variables for each potential edge.  We work with the explicit
+index set of non-diagonal pairs in `Sym2 (Fin n)` so that the resulting
+simple graphs have no loops.  The definitions introduced here establish
+the random graph as a measurable function into `SimpleGraph (Fin n)` and
+record basic sanity checks on small examples.
+
+TODO (Stage 2): extend these constructions with the expectation and
+integrability lemmas described in the roadmap, notably the
+`integrable_countCopies` statement from §2 of the paper.
+-/
+
+namespace Codex
+
+open Classical
+open Sym2
+open scoped BigOperators MeasureTheory ProbabilityTheory
+open MeasureTheory
+
+/-- The index type for undirected edges on `Fin n` obtained by removing the
+looping pairs from `Sym2 (Fin n)`.  Each element corresponds to one possible
+edge in the binomial random graph. -/
+def EdgePairs (n : ℕ) := {e : Sym2 (Fin n) // ¬ e.IsDiag}
+
+namespace Stage2
+
+variable {n : ℕ}
+
+instance instFintypeEdgePairs (n : ℕ) : Fintype (EdgePairs n) := by
+  classical
+  refine Fintype.subtype
+    (((Finset.univ : Finset (Sym2 (Fin n))).filter fun e => ¬ e.IsDiag)) ?_
+  intro e
+  by_cases he : e.IsDiag
+  · simp [Finset.mem_filter, he]
+  · simp [Finset.mem_filter, he]
+
+/-- The Bernoulli `PMF` on `Bool` with parameter `p ∈ [0, 1]`.  We work with
+nonnegative reals internally so that the associated `Measure` is a genuine
+probability measure without additional bookkeeping. -/
+noncomputable def bernoulliPMF (p : ℝ) (hp : 0 ≤ p ∧ p ≤ 1) : PMF Bool :=
+  PMF.bernoulli ⟨p, hp.1⟩ (by exact_mod_cast hp.2)
+
+/-- The Bernoulli probability measure on `Bool` with parameter `p ∈ [0, 1]`. -/
+noncomputable def bernoulliMeasure (p : ℝ) (hp : 0 ≤ p ∧ p ≤ 1) : Measure Bool :=
+  (bernoulliPMF p hp).toMeasure
+
+instance isProbabilityMeasure_bernoulli (p : ℝ) (hp : 0 ≤ p ∧ p ≤ 1) :
+    IsProbabilityMeasure (bernoulliMeasure p hp) := by
+  dsimp [bernoulliMeasure]
+  infer_instance
+
+/-- The product measure describing independent edge indicators for `G(n,p)`. -/
+noncomputable def gnpSampleMeasure (n : ℕ) (p : ℝ) (hp : 0 ≤ p ∧ p ≤ 1) :
+    Measure (EdgePairs n → Bool) :=
+  Measure.pi fun _ : EdgePairs n => bernoulliMeasure p hp
+
+/-- Extend an outcome on the edge index set to a Boolean indicator on all of
+`Sym2 (Fin n)` by forcing diagonal elements to be absent. -/
+noncomputable def edgeIndicator (ω : EdgePairs n → Bool) : Sym2 (Fin n) → Bool :=
+  fun e => if h : ¬ e.IsDiag then ω ⟨e, h⟩ else false
+
+@[simp]
+lemma edgeIndicator_diag (ω : EdgePairs n → Bool) (e : Sym2 (Fin n))
+    (he : e.IsDiag) : edgeIndicator (n := n) ω e = false := by
+  classical
+  simp [edgeIndicator, he]
+
+@[simp]
+lemma edgeIndicator_nonDiag (ω : EdgePairs n → Bool) (e : Sym2 (Fin n))
+    (he : ¬ e.IsDiag) : edgeIndicator (n := n) ω e = ω ⟨e, he⟩ := by
+  classical
+  simp [edgeIndicator, he]
+
+/-- The random edge set extracted from an indicator configuration. -/
+noncomputable def edgeSet (ω : EdgePairs n → Bool) : Set (Sym2 (Fin n)) :=
+  {e | edgeIndicator (n := n) ω e = true}
+
+/-- The simple graph realised by a given outcome of the edge indicators. -/
+noncomputable def gnpGraph (ω : EdgePairs n → Bool) : SimpleGraph (Fin n) :=
+  SimpleGraph.fromEdgeSet (edgeSet (n := n) ω)
+
+/-- The `G(n,p)` random variable viewed as a function into labelled simple
+graphs on `Fin n`. -/
+noncomputable def gnp (n : ℕ) : (EdgePairs n → Bool) → SimpleGraph (Fin n) :=
+  gnpGraph (n := n)
+
+@[simp]
+lemma gnp_adj (ω : EdgePairs n → Bool) {u v : Fin n} :
+    (gnp (n := n) ω).Adj u v ↔
+      edgeIndicator (n := n) ω s(u, v) = true ∧ u ≠ v := by
+  classical
+  simp [gnp, gnpGraph, edgeSet, edgeIndicator]
+
+instance instMeasurableSpaceSimpleGraphFin (n : ℕ) :
+    MeasurableSpace (SimpleGraph (Fin n)) := ⊤
+
+@[measurability]
+lemma measurable_gnp (n : ℕ) : Measurable (gnp (n := n)) := by
+  classical
+  simpa [gnp] using (measurable_of_finite (f := gnpGraph (n := n)))
+
+/-- The distribution of `G(n,p)` obtained by pushing forward the product
+measure on edge indicators. -/
+noncomputable def gnpDistribution (n : ℕ) (p : ℝ) (hp : 0 ≤ p ∧ p ≤ 1) :
+    Measure (SimpleGraph (Fin n)) :=
+  (gnpSampleMeasure (n := n) (p := p) hp).map (gnp (n := n))
+
+lemma gnpDistribution_apply (n : ℕ) (p : ℝ) (hp : 0 ≤ p ∧ p ≤ 1)
+    (s : Set (SimpleGraph (Fin n))) (hs : MeasurableSet s) :
+    gnpDistribution (n := n) (p := p) hp s =
+      gnpSampleMeasure (n := n) (p := p) hp ((gnp (n := n)) ⁻¹' s) := by
+  classical
+  simpa [gnpDistribution] using
+    Measure.map_apply (measurable_gnp (n := n)) hs
+
+/-- Sanity check: for `n = 2`, the empty indicator configuration realises the
+empty graph. -/
+example :
+    ¬ (gnp (n := 2) (fun _ : EdgePairs 2 => false)).Adj 0 1 := by
+  classical
+  simp [gnp_adj]
+
+/-- Sanity check: the configuration selecting the unique off-diagonal pair in
+`Fin 2` realises the single edge `0-1`. -/
+example :
+    (gnp (n := 2)
+      (fun e : EdgePairs 2 => if e.1 = s((0 : Fin 2), (1 : Fin 2)) then true else false)).Adj 0 1 := by
+  classical
+  have hpair :
+      s((0 : Fin 2), (1 : Fin 2)).IsDiag = False := by decide
+  have hneq : (0 : Fin 2) ≠ 1 := by decide
+  simp [gnp_adj, edgeIndicator, hpair, hneq]
+
+end Stage2
+
+end Codex

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Goal: formalize the probabilistic objects \(G(n,p)\) and compute expectations us
 Lean tasks:
 
 1. **Probability space for `G(n, p)`.**
-   - [ ] Model `G(n, p)` as the product measure on edge indicators. Use `SimpleGraph` and random edge subsets, employing `MeasureTheory` and `Probability` APIs in `mathlib`.
-   - [ ] Define `gnp (n : ℕ) (p : ℝ)` returning a random variable valued in `SimpleGraph (Fin n)`.
-   - [ ] Confirm measurability and integrability obligations explicitly with Lean proofs (`measurable_gnp`, `integrable_countCopies`) and tag the statements with documentation notes referencing the paper.
+   - [x] Model `G(n, p)` as the product measure on edge indicators. Use `SimpleGraph` and random edge subsets, employing `MeasureTheory` and `Probability` APIs in `mathlib`.
+   - [x] Define `gnp (n : ℕ) (p : ℝ)` returning a random variable valued in `SimpleGraph (Fin n)`.
+   - [ ] Confirm measurability and integrability obligations explicitly with Lean proofs (`measurable_gnp`, `integrable_countCopies`) and tag the statements with documentation notes referencing the paper. *(Measurability is now available via `Stage2.measurable_gnp`; integrability remains pending.)*
 
 2. **Random variables counting subgraphs.**
    - [ ] For each finite graph `H'`, define `countCopiesInRandomGraph` returning a random variable `Z_{H'}`. Use independence to show `ℙ[Z_{H'} ≥ t]` type statements.
@@ -76,6 +76,8 @@ Lean tasks:
 3. **Tail bounds via Markov.**
    - [ ] Formalize Markov's inequality using `mathlib`'s version and instantiate it for `Z_{H'}`. This verifies the inequalities `p_E ≤ p_Etilde ≤ p_crit`.
    - [ ] Capture the instantiated inequalities as Lean lemmas (`pE_le_pEtilde`, `pEtilde_le_pCrit`) and add `@[simp]` or `lemma` wrappers to make them directly reusable in Stage 3.
+
+*Status (Stage 2):* The module `Formalization/Stage2/RandomGraph.lean` introduces the Bernoulli product measure over edge indicators, the random variable `gnp`, and the measurability lemma `Stage2.measurable_gnp`. The remaining tasks focus on integrability statements and expectation computations for subgraph-counting random variables.
 
 ### Stage 3 — Threshold Definitions
 


### PR DESCRIPTION
## Summary
- introduce `Formalization.Stage2.RandomGraph` with the Bernoulli product measure on edge indicators
- define the `gnp` random variable, its measurability lemma, and the induced distribution
- record small sanity-check examples and import the new module from the library root while documenting progress in the README

## Testing
- `lake build`


------
https://chatgpt.com/codex/tasks/task_e_68d2a1ab0dc88323bdc06f9ab8a20fc6