### PR TITLE
Fix unused variable warnings in Stage1 graph lemmas

### DIFF
--- a/Formalization/Stage1/FiniteSimpleGraphs.lean
+++ b/Formalization/Stage1/FiniteSimpleGraphs.lean
@@ -552,7 +552,7 @@ lemma countCopies_subtype_completeGraph (J : SimpleGraph α) (H : SimpleGraph β
 noncomputable def embeddingPairsEquiv (J : SimpleGraph α) (H : SimpleGraph β)
     (G : SimpleGraph γ)
     [Fintype α] [Fintype β] [Fintype γ] :
-    (Σ f : H ↪g G, J ↪g H)
+    (Σ (_ : H ↪g G), J ↪g H)
       ≃ Σ g : J ↪g G,
           {f : H ↪g G |
               Set.range g.toEmbedding ⊆ Set.range f.toEmbedding} := by
@@ -788,7 +788,7 @@ example :
   lemma card_sigma_embeddings
     {J : SimpleGraph α} {H : SimpleGraph β} {G : SimpleGraph γ}
     [Fintype α] [Fintype β] [Fintype γ] :
-    Fintype.card (Σ f : H ↪g G, J ↪g H)
+    Fintype.card (Σ (_ : H ↪g G), J ↪g H)
       = countCopies H G * countCopies J H := by
   classical
   have hSigma :

--- a/Formalization/Stage1/FiniteSimpleGraphs.lean
+++ b/Formalization/Stage1/FiniteSimpleGraphs.lean
@@ -191,14 +191,15 @@ lemma edgeCount_graphOfEdgeFinset_of_loopless {n : ℕ}
   have h := edgeCount_graphOfEdgeFinset (n := n) (edges := edges)
   calc
     edgeCount (graphOfEdgeFinset n edges) = (edges.filter fun e => ¬ e.IsDiag).card := h
-    _ = edges.card := by simpa [hfilter]
+    _ = edges.card := by
+      simp [hfilter]
 
 /-- Sanity check: the complete graph on three labelled vertices has three edges. -/
 example : edgeCount (SimpleGraph.completeGraph (Fin 3)) = 3 := by
   classical
   have h := edgeCount_completeGraph (n := 3)
-  have : Nat.choose 3 2 = 3 := by decide
-  simpa [this] using h
+  have hchoose : Nat.choose 3 2 = 3 := by decide
+  exact hchoose ▸ h
 
 /-- Sanity check: constructing `K₃` with one edge removed via `graphOfEdgeFinset`
 records exactly two edges. -/


### PR DESCRIPTION
## Summary
- replace sigma binders with anonymous binders in Stage1 finite graph lemmas to avoid unused variable linter warnings

## Testing
- `lake build`


------
https://chatgpt.com/codex/tasks/task_e_68de64751fb48323a8c208892a8e22c5